### PR TITLE
Add link to live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 3D-visuals
 
 This project hosts a holographic air quality dashboard implemented in vanilla HTML, CSS and JavaScript. A live build of `dashboard_v3.html` is published using GitHub Pages so you can view the interface without cloning the repository.
+[View the live site here](https://kapil2020.github.io/3D-visuals/)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add a link to the deployed dashboard

## Testing
- `npm test` *(fails: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_684dda6e75e883308f505683f2f05ec7